### PR TITLE
Enabled methods to take in os.PathLike objects instead of just strings + fixed various typos in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,50 +22,47 @@ This class requires no instance to function (i.e. it is fully static)
 
 These are all methods that JsoncParser class provides for working with .jsonc files:
 
--   ##### JsoncParser.parse_file(filepath: str) -> dict
+-   ##### JsoncParser.parse_file(filepath: PathLike) -> dict
 
     This function parses file, specified in _filepath_ parameter, and deserializes it into a valid Python object (dictionary), removing any comment in the process. No alterations are made it the file itself. _filepath_ parameter specifies path to .jsonc file.
 
         from jsonc-parser.parser import JsoncParser
 
         file_path = "./data.jsonc"
-        # Content from 'data.jsonc' -> {"version": "1.0.0", /*This is my project's version*/}
+        # Content from 'data.jsonc' -> {"version": "1.0.0" /*This is my project's version*/}
 
         data = JsoncParser.parse_file(file_path)
 
         print(data)
         # Output: {'version': '1.0.0'}
 
-    This function can raise _[FunctionParameterError](#exc-function-parameter-error)_ if filepath parameter is not a string or is empty. Also this function will raise _[FileError](#exc-file-error)_ exception if file's format is unsupported and a _[ParserError](#exc-parser-error)_ exception if file cannot be parsed/contains invalid JSON data.
+    This function can raise _[FunctionParameterError](#exc-function-parameter-error)_ if filepath parameter is not a path-like object (str, bytes object representing a path, or os.PathLike compliant) or is empty. Also this function will raise _[FileError](#exc-file-error)_ exception if file's format is unsupported and a _[ParserError](#exc-parser-error)_ exception if file cannot be parsed/contains invalid JSON data.
 
--   ##### JsoncParser.parse_str(filepath: str) -> dict
+-   ##### JsoncParser.parse_str(_string: str) -> dict
 
     This function parses string, specified in __string_ parameter, and deserializes it into a valid Python object (dictionary), removing any comment in the process.
 
         from jsonc-parser.parser import JsoncParser
 
-        file_path = "./data.jsonc"
-        # Content from 'data.jsonc' -> {"version": "1.0.0", /*This is my project's version*/}
+        json_string = """{"version": "1.0.0" /*This is my project's version*/}"""
 
-        data = JsoncParser.parse_file(file_path)
+        data = JsoncParser.parse_str(json_string)
 
         print(data)
         # Output: {'version': '1.0.0'}
 
     This function can raise _[FunctionParameterError](#exc-function-parameter-error)_ if __string_ parameter is not a string or is empty. Also this function will raise a _[ParserError](#exc-parser-error)_ exception if file cannot be parsed/contains invalid JSON data.
 
--   ##### JsoncParser.convert_to_json(filepath: str, remove_file: bool = False) -> None
+    ##### JsoncParser.convert_to_json(filepath: PathLike, remove_file: bool = False) -> None
+    This function converts file from .jsonc to .json format, removing any comments in the process. filepath parameter specifies path to file and remove_file parameter specifies if .jsonc file will be removed (deleted from hard drive) after conversion. If set to True, this function will delete .jsonc file leaving only .json file. Otherwise, both files are not deleted. This function can raise _[FunctionParameterError](#exc-function-parameter-error)_ if _filepath_ parameter is not a path-like object or is empty or if _remove_file_ parameter is not a boolean.
 
-    This function converts file from .jsonc to .json format, removing any comments in the process. _filepath_ parameter specifies path to file and _remove_file_ parameter specifies if .jsonc file will be removed (deleted from hard drive) after conversion. If set to True, this function will delete .jsonc file leaving only .json file. Otherwise, both files are not deleted.
-    This function can raise _[FunctionParameterError](#exc-function-parameter-error)_ if _filepath_ parameter is not a string or is empty or if _remove_file_ parameter is not a boolean.
-
--   ##### JsoncParser.convert_to_jsonc(filepath: str, remove_file: bool = False) -> None
+-   ##### JsoncParser.convert_to_jsonc(filepath: PathLike, remove_file: bool = False) -> None
     This function converts file from .json to .jsonc format, enabling comment support. filepath parameter specifies path to file and _remove_file_ parameter specifies if .jsonc file will be removed (deleted from hard drive) after conversion. If set to True, this function will delete .jsonc file leaving only .json file. Otherwise, both files are not deleted.
-    This function can raise _[FunctionParameterError](#exc-function-parameter-error)_ if _filepath_ parameter is not a string or is empty or if _remove_file_ parameter is not a boolean.
+    This function can raise _[FunctionParameterError](#exc-function-parameter-error)_ if _filepath_ parameter is not a path-like object or is empty or if _remove_file_ parameter is not a boolean.
 
 ## Exceptions
 
-There are a total of 3 custom exceptions that jsonc-parser can raise during its runtime. To access the in your script, simply imprt thef from class='exc-code'>jsonc_parser.errors module:
+There are a total of 3 custom exceptions that jsonc-parser can raise during its runtime. To access the in your script, simply import them from jsonc_parser.errors module:
 
     from jsonc_parser.errors import FileError, IncorrectParameterError, ParserError
 
@@ -77,8 +74,8 @@ There are a total of 3 custom exceptions that jsonc-parser can raise during its 
 
 -   **FunctionParameterError**
     <div id='exc-function-parameter-error'></div>
-    This exception indicates that some of function's parameters are invalid. They may have wrong type, have invalid values or be errorous in some other way.
+    This exception indicates that some of function's parameters are invalid. They may have wrong type, have invalid values or be erroneous in some other way.
 
 -   **ParserError**
     <div id='exc-parser-error'></div>
-    This exception indicates that file cannot be parsed. It can have wrong extension, invalid data, etc
+    This exception indicates that file cannot be parsed. It can have wrong extension, invalid data, etc.

--- a/jsonc_parser/parser.py
+++ b/jsonc_parser/parser.py
@@ -2,6 +2,7 @@ import json
 import re
 from jsonc_parser.errors import FileError, FunctionParameterError, ParserError
 import os
+from typing import Union
 
 
 class JsoncParser:
@@ -19,7 +20,7 @@ class JsoncParser:
 
         This function will raise a `FunctionParameterError` exception if `_string` parameter
         has an incorrect type or is empty.
-        This function will raise a `ParserError` exception if file cannot be parsed.
+        This function will raise a `ParserError` exception if the string cannot be parsed.
         This function will raise any additional exceptions if occurred.
         """
 
@@ -34,26 +35,19 @@ class JsoncParser:
                 "_string parameter must be str; got {} instead".format(type(_string).__name__)
             )
 
-        if not _string:
-            raise FunctionParameterError("there is not JSONC to be parsed")
-
-        json_file = open(_string, "r")
-        data_raw = json_file.read()
-        json_file.close()
-
         try:
-            data = JsoncParser.regex.sub(__re_sub, data_raw)
+            data = JsoncParser.regex.sub(__re_sub, _string)
             return json.loads(JsoncParser.regex.sub(__re_sub, data))
         except Exception as e:
             raise ParserError("{} file cannot be parsed (message: {})".format(_string, str(e)))
 
     @staticmethod
-    def parse_file(filepath: str) -> dict:
+    def parse_file(filepath: Union[str, os.PathLike]) -> dict:
         """
         Parse .jsonc file and deserialize its content into Python dictionary,
         ignoring any comments.
 
-        Parameters: `filepath:str` - path to file
+        Parameters: `filepath: str | os.PathLike` - path to file
 
         This function will raise a `FunctionParameterError` exception if `filepath` parameter
         has an incorrect type or is empty.
@@ -67,10 +61,13 @@ class JsoncParser:
                 return ""
             else:
                 return match.group(1)
-
-        if type(filepath) != str:
+        
+        # verify that provided path is a valid path-like object
+        try:
+            filepath = os.fspath(filepath)
+        except TypeError:
             raise FunctionParameterError(
-                "filepath parameter must be str; got {} instead".format(type(filepath).__name__)
+                "filepath parameter must be path-like; got {} instead".format(type(path).__name__)
             )
 
         if not filepath:
@@ -93,13 +90,13 @@ class JsoncParser:
             raise ParserError("{} file cannot be parsed (message: {})".format(filepath, str(e)))
 
     @staticmethod
-    def convert_to_json(filepath: str, remove_file: bool = False) -> None:
+    def convert_to_json(filepath: Union[str, os.PathLike], remove_file: bool = False) -> None:
         """
         Convert file from .jsonc to .json format, removing any comments from it
 
-        Parameters: `filepath:str` is a path to file, `remove_file:bool` indicates if source file
-        will be deleted or not. If set to True, .jsonc file will be deleted from the hard drive,
-        otherwise file remains alongside with its .json output.
+        Parameters: `path: str | os.PathLike` is a path to file, `remove_file:bool` indicates if
+        source file will be deleted or not. If set to True, .jsonc file will be deleted from the
+        hard drive, otherwise file remains alongside with its .json output.
 
         This function will raise a `FunctionParameterError` if one or more of function's parameters
         has an incorrect type/invalid value.
@@ -107,9 +104,12 @@ class JsoncParser:
 
         """
 
-        if type(filepath) != str:
+        # verify that provided path is a valid path-like object
+        try:
+            filepath = os.fspath(filepath)
+        except TypeError:
             raise FunctionParameterError(
-                "filepath parameter must be str; got {} instead".format(type(filepath).__name__)
+                "filepath parameter must be path-like; got {} instead".format(type(path).__name__)
             )
 
         if not filepath:
@@ -136,21 +136,24 @@ class JsoncParser:
         json_file.close()
 
     @staticmethod
-    def convert_to_jsonc(filepath: str, remove_file: bool = False):
+    def convert_to_jsonc(filepath: Union[str, os.PathLike], remove_file: bool = False):
         """
         Convert file .jsonc format, enabling comments.
 
-        Parameters: `filepath:str` is a path to file, `remove_file:bool` indicates if source file
-        will be deleted or not. If set to True, .json file will be deleted from the hard drive,
-        otherwise file remains alongside with its .jsonc output.
+        Parameters: `filepath: str | os.PathLike` is a path to file, `remove_file:bool` indicates
+        if source file will be deleted or not. If set to True, .json file will be deleted from the
+        hard drive, otherwise file remains alongside with its .jsonc output.
 
         This function will raise a `FunctionParameterError` if one or more of function's parameters
         has an incorrect type/invalid value.
         This function will raise any additional exceptions if occurred.
         """
-        if type(filepath) != str:
+        # verify that provided path is a valid path-like object
+        try:
+            filepath = os.fspath(filepath)
+        except TypeError:
             raise FunctionParameterError(
-                "filepath parameter must be str; got {} instead".format(type(filepath).__name__)
+                "filepath parameter must be path-like; got {} instead".format(type(path).__name__)
             )
 
         if not filepath:


### PR DESCRIPTION
Hi, thanks for the very useful package. I had one issue with it, in order to load _jsonc_ files from pathlib.Path objects I had to manually convert them to strings, which is a bit of a shame. So anyway I added support for the os.PathLike interface, this allows the methods to use paths of any type that implement this built-in protocol. This shouldn't have any impact on the existing functionality but will make this package easier to use in conjunction with others.

Also found a few typos while I was updating the readme so I fixed them :)